### PR TITLE
Change `isReviewed` -> `isApproved`

### DIFF
--- a/Sources/mariachiLib/GitHub/GitHubModels.swift
+++ b/Sources/mariachiLib/GitHub/GitHubModels.swift
@@ -79,7 +79,7 @@ public class Review: Decodable {
       state
   }
 
-  var isReviewed: Bool {
+  var isApproved: Bool {
       reviewState == "APPROVED"
   }
 }
@@ -100,7 +100,7 @@ public extension Array where Element: PullRequest {
   func needing(minApprovals: Int) -> [PullRequest] {
       var needingApprovalsTemp = [PullRequest]()
       for pull in self {
-        let validReviews = pull.reviews?.filter { $0.isReviewed }.uniquingReviewers.count ?? 0
+        let validReviews = pull.reviews?.filter { $0.isApproved }.uniquingReviewers.count ?? 0
           if validReviews < minApprovals {
               needingApprovalsTemp.append(pull)
           }

--- a/Tests/mariachiUnitTests/MariachiUnitTests.swift
+++ b/Tests/mariachiUnitTests/MariachiUnitTests.swift
@@ -34,9 +34,9 @@ final class MariachiUnitTests: XCTestCase {
     let reviewData = try JSONSerialization.data(withJSONObject: reviewsData, options: [])
     let reviews = try JSONDecoder().decode([Review].self, from: reviewData)
 
-    XCTAssertTrue(reviews[0].isReviewed)
-    XCTAssertTrue(reviews[1].isReviewed)
-    XCTAssertFalse(reviews[2].isReviewed)
+    XCTAssertTrue(reviews[0].isApproved)
+    XCTAssertFalse(reviews[1].isApproved)
+    XCTAssertFalse(reviews[2].isApproved)
   }
 
   func testUniquingUsers() throws {


### PR DESCRIPTION
See #10 - this PR renames a property in `Review` to match its intent, which is to indicate that said `Review` is in approved state and not simply review.