### PR TITLE
Update github_token input to be required in action definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ on:
 jobs:
   look_for_prs_needing_reviews:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
     - name: Mariachi
       uses: schlagelk/mariachi:main
       with:
         # Required:
         teams_url: ${{ secrets.TEAMS_TOKEN }} # your Teams channel's webhook URL. here we assume it's in your repo's secrets store
+        github_token: ${{ secrets.GITHUB_TOKEN }} # Make sure you include the job permission pull-requests: read
         # Optional:
-        github_token: ${{ secrets.GITHUB_TOKEN }} # Uses the default Github Actions token created by Github. You can also use a personal access token with repo scope enabled, but this one is already available
         exclude_heads: release,foo,bar
         exclude_labels: skip-reminder,do not review
         min_reviews: 3

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,8 @@ name: 'Mariachi'
 description: 'Sends Pull Request review reminders to Microsoft Teams channels'
 inputs:
   github_token:
-    description: 'This is the default token set and created by GitHub. You can also use a personal access token with repo scope enabled, but this one is already available'
-    required: false
-    default: ${{ github.token }}
+    description: 'The GITHUB_TOKEN secret. It must have the pull-requests: read permission. You can also use a personal access token with repo scope enabled, but this one is already available'
+    required: true
   teams_url: 
     description: 'Your Teams channel's webhook URL. Here we assume it's in your repo's secrets store'
     required: true

--- a/docs/index.html
+++ b/docs/index.html
@@ -201,8 +201,8 @@
         <span class="pl-ent">with</span>:
           <span class='comment'># Required:</span>
           <span class="pl-ent">teams_url</span>: <span class="pl-s">${{ secrets.TEAMS_TOKEN }} </span><span class='comment'># your Teams URL from step 1</span>
+          <span class="pl-ent">github_token</span>: <span class="pl-s">${{ secrets.GITHUB_TOKEN }}</span><span class='comment'> # Make sure you include the job permission pull-requests: read</span>
           <span class='comment'># Optional:</span>
-          <span class="pl-ent">github_token</span>: <span class="pl-s">${{ secrets.GITHUB_TOKEN }}</span><span class='comment'> # # Uses the default Github Actions token created by Github. You can also use a personal access token with repo scope enabled, but this one is already available</span>
           <span class="pl-ent">exclude_heads</span>: <span class="pl-s">release,test</span>
           <span class="pl-ent">exclude_labels</span>: <span class="pl-s">do-not-review,skip-mariachi</span>
           <span class="pl-ent">min_reviews</span>: <span class="pl-c1">3</span><span class='comment'> # Defaults to 2</span></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -195,6 +195,8 @@
   <span class="pl-ent">jobs</span>:
     <span class="pl-ent">remind</span>:
       <span class="pl-ent">runs-on</span>: <span class="pl-s">ubuntu-latest</span>
+      <span class="pl-ent">permissions/span>:
+        <span class="pl-ent">pull-requests</span>: <span class="pl-s">read</span>
       <span class="pl-ent">steps</span>:
       - <span class="pl-ent">name</span>: <span class="pl-s">Mariachi</span>
       <span class="pl-ent">uses</span>: <span class="pl-s">schlagelk/mariachi:main</span>


### PR DESCRIPTION
I think this might fix why the action isn't available to add to the marketplace from https://github.com/schlagelk/Mariachi/pull/12